### PR TITLE
Add toggle for Shift+CapsLock behavior and use checkmarks in tray menu

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ pub struct AppState {
     _is_previous_mode: RwLock<bool>,
     _prev_layout: RwLock<Option<HKL>>,
     _keep_lock: RwLock<bool>,
+    _default_capslock_behaviour: RwLock<bool>,
 }
 
 impl AppState {
@@ -25,6 +26,7 @@ impl AppState {
             _is_previous_mode: RwLock::new(args.get(1).map_or(false, |mode| mode == "--previous")),
             _prev_layout: RwLock::new(None),
             _keep_lock: RwLock::new(false),
+            _default_capslock_behaviour: RwLock::new(true),
         }
     }
 
@@ -94,6 +96,30 @@ impl AppState {
         drop(is_previous_mode);
 
         self.is_previous_mode()
+    }
+    fn is_default_capslock_behaviour_enabled(&self) -> Result<bool, String> {
+        let is_enabled = *self
+            ._default_capslock_behaviour
+            .read()
+            .map_err(|e| format!("Failed to read `default_capslock_behaviour`: {}", e))?;
+
+        Ok(is_enabled)
+    }
+
+    fn toggle_default_capslock_behaviour(&self) -> Result<bool, String> {
+        let mut is_enabled = self
+            ._default_capslock_behaviour
+            .write()
+            .map_err(|e| format!("Failed to write `default_capslock_behaviour`: {}", e))?;
+        let mut _keep_lock = self
+            ._keep_lock
+            .write()
+            .map_err(|e| format!("Failed to write `keep_lock`: {}", e))?;
+
+        *is_enabled = !*is_enabled;
+        drop(is_enabled);
+
+        self.is_default_capslock_behaviour_enabled()
     }
 }
 

--- a/src/switch.rs
+++ b/src/switch.rs
@@ -73,6 +73,32 @@ fn imitate_keyboard_layout_change() {
     }
 }
 
+fn toggle_capslock() {
+    let input = INPUT {
+        r#type: INPUT_KEYBOARD,
+        Anonymous: INPUT_0 {
+            ki: KEYBDINPUT {
+                wVk: VIRTUAL_KEY(VK_CAPITAL.0),
+                wScan: 0,
+                dwFlags: KEYEVENTF_EXTENDEDKEY,
+                time: 0,
+                dwExtraInfo: 0,
+            },
+        },
+    };
+
+    let result = unsafe {
+        SendInput(
+            &[input],
+            i32::try_from(mem::size_of::<INPUT>()).expect("Converting sizeof Input Failed"),
+        )
+    };
+
+    if result == 0 {
+        panic!("SendInput failed");
+    }
+}
+
 unsafe extern "system" fn keyboard_hook_proc(code: i32, wparam: WPARAM, lparam: LPARAM) -> LRESULT {
     match APP_STATE.is_paused() {
         Ok(is_paused) => {
@@ -88,74 +114,68 @@ unsafe extern "system" fn keyboard_hook_proc(code: i32, wparam: WPARAM, lparam: 
 
     if code >= 0 {
         let kb_struct = &*(lparam.0 as *const KBDLLHOOKSTRUCT);
-
         if kb_struct.vkCode == u32::from(VK_CAPITAL.0) {
             if wparam.0 == WM_KEYDOWN as usize {
                 let shift_state = GetAsyncKeyState(i32::from(VK_SHIFT.0));
                 if (shift_state as i16) < 0 {
                     // shift is pressed
-                    let input = INPUT {
-                        r#type: INPUT_KEYBOARD,
-                        Anonymous: INPUT_0 {
-                            ki: KEYBDINPUT {
-                                wVk: VIRTUAL_KEY(VK_CAPITAL.0),
-                                wScan: 0,
-                                dwFlags: KEYEVENTF_EXTENDEDKEY,
-                                time: 0,
-                                dwExtraInfo: 0,
-                            },
-                        },
-                    };
-                    let cb_size = i32::try_from(mem::size_of::<INPUT>());
-                    match cb_size {
-                        Ok(cb_size) => {
-                            SendInput(&[input], cb_size);
-                        }
-                        Err(_) => panic!("SendInput failed"),
-                    }
-                } else {
-                    let curr_layout = get_foreground_layout();
-                    let is_prev_mode = APP_STATE.is_previous_mode().unwrap_or_else(|e| {
-                        eprintln!("Error: {e}");
-                        false
-                    });
-
-                    if !is_prev_mode {
-                        imitate_keyboard_layout_change();
-                    } else {
-                        let previous_layout = APP_STATE.prev_layout().unwrap_or_else(|e| {
-                            eprintln!("Error: {e}");
-                            None
+                    let is_default_behaviour_enabled = APP_STATE
+                        .is_default_capslock_behaviour_enabled()
+                        .unwrap_or_else(|e| {
+                            eprintln!("Error checking default capslock behaviour setting: {}", e);
+                            true
                         });
-                        match previous_layout {
-                            Some(prev_layout) => {
-                                if curr_layout == prev_layout {
-                                    imitate_keyboard_layout_change();
-                                } else {
-                                    let result = change_keyboard_layout(&prev_layout);
-                                    // In case of success
-                                    if result.0 == 0 {
-                                        match APP_STATE.set_prev_layout(Some(curr_layout)) {
-                                            Ok(_) => {}
-                                            Err(err) => {
-                                                eprintln!("Didn't manage to set previous layout to state. Error: {}", err)
-                                            }
+
+                    if is_default_behaviour_enabled {
+                        toggle_capslock();
+                    }
+                }
+
+                let curr_layout = get_foreground_layout();
+                let is_prev_mode = APP_STATE.is_previous_mode().unwrap_or_else(|e| {
+                    eprintln!("Error: {e}");
+                    false
+                });
+
+                if !is_prev_mode {
+                    imitate_keyboard_layout_change();
+                } else {
+                    let previous_layout = APP_STATE.prev_layout().unwrap_or_else(|e| {
+                        eprintln!("Error: {e}");
+                        None
+                    });
+                    match previous_layout {
+                        Some(prev_layout) => {
+                            if curr_layout == prev_layout {
+                                imitate_keyboard_layout_change();
+                            } else {
+                                let result = change_keyboard_layout(&prev_layout);
+                                // In case of success
+                                if result.0 == 0 {
+                                    match APP_STATE.set_prev_layout(Some(curr_layout)) {
+                                        Ok(_) => {}
+                                        Err(err) => {
+                                            eprintln!("Didn't manage to set previous layout to state. Error: {}", err)
                                         }
                                     }
                                 }
                             }
-                            None => {
-                                match APP_STATE.set_prev_layout(Some(curr_layout)) {
-                                    Ok(_) => {}
-                                    Err(err) => {
-                                        eprintln!("Didn't manage to set previous layout to state. Error: {}", err)
-                                    }
+                        }
+                        None => {
+                            match APP_STATE.set_prev_layout(Some(curr_layout)) {
+                                Ok(_) => {}
+                                Err(err) => {
+                                    eprintln!(
+                                        "Didn't manage to set previous layout to state. Error: {}",
+                                        err
+                                    )
                                 }
-                                imitate_keyboard_layout_change();
                             }
+                            imitate_keyboard_layout_change();
                         }
                     }
                 }
+
                 return LRESULT(1);
             }
         }

--- a/src/tray.rs
+++ b/src/tray.rs
@@ -4,6 +4,7 @@ use image::ImageReader;
 use std::{env, process, thread};
 use tray_icon::{
     menu::{
+        accelerator::{Accelerator, Code, Modifiers},
         AboutMetadata, AboutMetadataBuilder, CheckMenuItem, CheckMenuItemBuilder, Menu, MenuEvent,
         MenuId, MenuItem, MenuItemBuilder, PredefinedMenuItem,
     },
@@ -11,57 +12,13 @@ use tray_icon::{
 };
 use windows::Win32::{Foundation::HWND, UI::WindowsAndMessaging::*};
 
-enum ModeLabel {
-    Previous,
-}
-
-impl ModeLabel {
-    fn as_str(&self) -> &str {
-        match self {
-            ModeLabel::Previous => "Previous mode",
-        }
-    }
-}
-
-enum ToggleLabel {
-    Pause,
-    Resume,
-}
-
-impl ToggleLabel {
-    fn as_str(&self) -> &str {
-        match self {
-            ToggleLabel::Pause => "Pause",
-            ToggleLabel::Resume => "Resume",
-        }
-    }
-}
-
-enum AutoloadLabel {
-    Autoload,
-}
-
-impl AutoloadLabel {
-    fn as_str(&self) -> &str {
-        match self {
-            AutoloadLabel::Autoload => "Autoload",
-        }
-    }
-}
-
-enum DefaultCapsLockBehaviourLabel {
-    DefaultCapsLockBehaviour,
-}
-
-impl DefaultCapsLockBehaviourLabel {
-    fn as_str(&self) -> &str {
-        match self {
-            DefaultCapsLockBehaviourLabel::DefaultCapsLockBehaviour => {
-                "Default CapsLock behaviour (Shift+CapsLock)"
-            }
-        }
-    }
-}
+const MODE_PREVIOUS: &str = "Previous mode";
+const TOGGLE_PAUSE: &str = "Pause";
+const TOGGLE_RESUME: &str = "Resume";
+const DEFAULT_CAPSLOCK_BEHAVIOUR: &str = "Default CapsLock behaviour";
+const AUTOLOAD: &str = "Autoload";
+const QUIT: &str = "Quit";
+const ABOUT: &str = "About";
 
 struct MenuItems {
     toggle: MenuItem,
@@ -110,45 +67,58 @@ fn get_metadata() -> AboutMetadata {
 fn get_menu_items() -> MenuItems {
     let menu_i_toggle: MenuItem = MenuItemBuilder::new()
         .id(MenuId::new("toggle"))
-        .text(ToggleLabel::Pause.as_str())
+        .text(TOGGLE_PAUSE)
         .enabled(true)
         .build();
+
     let top_separator = PredefinedMenuItem::separator();
+
     let menu_i_prev_mode: CheckMenuItem = CheckMenuItemBuilder::new()
         .id(MenuId::new("mode"))
-        .text(ModeLabel::Previous.as_str())
+        .text(MODE_PREVIOUS)
         .checked(APP_STATE.is_previous_mode().unwrap())
         .enabled(true)
         .build();
     let menu_i_default_capslock_behaviour: CheckMenuItem = CheckMenuItemBuilder::new()
         .id(MenuId::new("default_capslock_behaviour"))
-        .text(DefaultCapsLockBehaviourLabel::DefaultCapsLockBehaviour.as_str())
+        .text(DEFAULT_CAPSLOCK_BEHAVIOUR)
         .checked(APP_STATE.is_default_capslock_behaviour_enabled().unwrap())
         .enabled(true)
         .build();
+    menu_i_default_capslock_behaviour
+        .set_accelerator(Some(Accelerator::new(
+            Some(Modifiers::SHIFT),
+            Code::CapsLock,
+        )))
+        .unwrap_or_else(|e| {
+            eprintln!(
+                "Failed to set accelerator for default CapsLock behaviour tray menu item: {}",
+                e
+            )
+        });
     let menu_i_autoload: CheckMenuItem = CheckMenuItemBuilder::new()
         .id(MenuId::new("autoload"))
-        .text(AutoloadLabel::Autoload.as_str())
+        .text(AUTOLOAD)
         .checked(is_autoload_enabled())
         .enabled(true)
         .build();
 
     let menu_i_quit: MenuItem = MenuItemBuilder::new()
         .id(MenuId::new("quit"))
-        .text("Quit")
+        .text(QUIT)
         .enabled(true)
         .build();
 
     let bottom_separator = PredefinedMenuItem::separator();
 
     let metadata = get_metadata();
-    let menu_i_about: PredefinedMenuItem = PredefinedMenuItem::about(Some("About"), Some(metadata));
+    let menu_i_about: PredefinedMenuItem = PredefinedMenuItem::about(Some(ABOUT), Some(metadata));
     let items = MenuItems {
         toggle: menu_i_toggle,
         top_separator,
         prev_mode: menu_i_prev_mode,
-        autoload: menu_i_autoload,
         default_capslock_behaviour: menu_i_default_capslock_behaviour,
+        autoload: menu_i_autoload,
         bottom_separator,
         about: menu_i_about,
         quit: menu_i_quit,
@@ -205,9 +175,9 @@ fn toggle_handler(menu_i: &MenuItem) {
     match APP_STATE.toggle_pause() {
         Ok(is_paused) => {
             let text = if is_paused {
-                ToggleLabel::Resume.as_str()
+                TOGGLE_RESUME
             } else {
-                ToggleLabel::Pause.as_str()
+                TOGGLE_PAUSE
             };
             menu_i.set_text(text);
         }
@@ -247,8 +217,8 @@ pub fn create_tray() {
                 &menu_items.toggle,
                 &menu_items.top_separator,
                 &menu_items.prev_mode,
-                &menu_items.autoload,
                 &menu_items.default_capslock_behaviour,
+                &menu_items.autoload,
                 &menu_items.bottom_separator,
                 &menu_items.about,
                 &menu_items.quit,

--- a/src/tray.rs
+++ b/src/tray.rs
@@ -73,10 +73,35 @@ impl AutoloadLabel {
     }
 }
 
+enum DefaultCapsLockBehaviourLabel {
+    Enabled,
+    Disabled,
+}
+
+impl DefaultCapsLockBehaviourLabel {
+    fn as_str(&self) -> String {
+        let prefix = "Default CapsLock behaviour (Shift+CapsLock):";
+
+        match self {
+            DefaultCapsLockBehaviourLabel::Enabled => format!("{} enabled", prefix),
+            DefaultCapsLockBehaviourLabel::Disabled => format!("{} disabled", prefix),
+        }
+    }
+
+    fn get_label(is_enabled: &bool) -> String {
+        if *is_enabled {
+            DefaultCapsLockBehaviourLabel::Enabled.as_str()
+        } else {
+            DefaultCapsLockBehaviourLabel::Disabled.as_str()
+        }
+    }
+}
+
 struct MenuItems {
     toggle: MenuItem,
     prev_mode: MenuItem,
     autoload: MenuItem,
+    default_capslock_behaviour: MenuItem,
     separator: PredefinedMenuItem,
     about: PredefinedMenuItem,
     quit: MenuItem,
@@ -126,12 +151,20 @@ fn get_menu_items() -> MenuItems {
         .text(ModeLabel::get_label(&APP_STATE.is_previous_mode().unwrap()))
         .enabled(true)
         .build();
-
     let menu_i_autoload: MenuItem = MenuItemBuilder::new()
         .id(MenuId::new("autoload"))
         .text(AutoloadLabel::get_label())
         .enabled(true)
         .build();
+
+    let menu_i_default_capslock_behaviour: MenuItem = MenuItemBuilder::new()
+        .id(MenuId::new("default_capslock_behaviour"))
+        .text(DefaultCapsLockBehaviourLabel::get_label(
+            &APP_STATE.is_default_capslock_behaviour_enabled().unwrap(),
+        ))
+        .enabled(true)
+        .build();
+
     let menu_i_quit: MenuItem = MenuItemBuilder::new()
         .id(MenuId::new("quit"))
         .text("Quit")
@@ -142,11 +175,11 @@ fn get_menu_items() -> MenuItems {
 
     let metadata = get_metadata();
     let menu_i_about: PredefinedMenuItem = PredefinedMenuItem::about(Some("About"), Some(metadata));
-
     let items = MenuItems {
         toggle: menu_i_toggle,
         prev_mode: menu_i_prev_mode,
         autoload: menu_i_autoload,
+        default_capslock_behaviour: menu_i_default_capslock_behaviour,
         separator,
         about: menu_i_about,
         quit: menu_i_quit,
@@ -222,6 +255,22 @@ fn quit_hander() {
     process::exit(0);
 }
 
+fn default_capslock_behaviour_handler(menu_i: &MenuItem) {
+    match APP_STATE.toggle_default_capslock_behaviour() {
+        Ok(is_enabled) => {
+            let text = DefaultCapsLockBehaviourLabel::get_label(&is_enabled);
+            menu_i.set_text(text);
+        }
+        Err(err) => {
+            eprintln!(
+                "Could not toggle default CapsLock behaviour setting: {}",
+                err
+            );
+            return;
+        }
+    }
+}
+
 pub fn create_tray() {
     thread::spawn(move || {
         let tray_menu: Menu = Menu::new();
@@ -231,6 +280,7 @@ pub fn create_tray() {
                 &menu_items.toggle,
                 &menu_items.prev_mode,
                 &menu_items.autoload,
+                &menu_items.default_capslock_behaviour,
                 &menu_items.separator,
                 &menu_items.about,
                 &menu_items.quit,
@@ -257,13 +307,15 @@ pub fn create_tray() {
                 if msg.message == WM_QUIT {
                     break;
                 }
-
                 if let Ok(event) = menu_event_rx.try_recv() {
                     match event.id.as_ref() {
                         "quit" => quit_hander(),
                         "autoload" => autoload_handler(&menu_items.autoload),
                         "mode" => mode_hander(&menu_items.prev_mode),
                         "toggle" => toggle_handler(&menu_items.toggle),
+                        "default_capslock_behaviour" => default_capslock_behaviour_handler(
+                            &menu_items.default_capslock_behaviour,
+                        ),
                         _ => {
                             println!("Menu item clicked: {:?}", event.id);
                         }

--- a/src/tray.rs
+++ b/src/tray.rs
@@ -4,33 +4,21 @@ use image::ImageReader;
 use std::{env, process, thread};
 use tray_icon::{
     menu::{
-        AboutMetadata, AboutMetadataBuilder, Menu, MenuEvent, MenuId, MenuItem, MenuItemBuilder,
-        PredefinedMenuItem,
+        AboutMetadata, AboutMetadataBuilder, CheckMenuItem, CheckMenuItemBuilder, Menu, MenuEvent,
+        MenuId, MenuItem, MenuItemBuilder, PredefinedMenuItem,
     },
     Icon, TrayIconBuilder,
 };
 use windows::Win32::{Foundation::HWND, UI::WindowsAndMessaging::*};
 
 enum ModeLabel {
-    Circular,
     Previous,
 }
 
 impl ModeLabel {
-    fn as_str(&self) -> String {
-        let prefix = "Previous mode:";
-
+    fn as_str(&self) -> &str {
         match self {
-            ModeLabel::Circular => format!("{} disabled", prefix),
-            ModeLabel::Previous => format!("{} enabled", prefix),
-        }
-    }
-
-    fn get_label(is_enabled: &bool) -> String {
-        if *is_enabled {
-            ModeLabel::Previous.as_str()
-        } else {
-            ModeLabel::Circular.as_str()
+            ModeLabel::Previous => "Previous mode",
         }
     }
 }
@@ -50,59 +38,38 @@ impl ToggleLabel {
 }
 
 enum AutoloadLabel {
-    Enabled,
-    Disabled,
+    Autoload,
 }
 
 impl AutoloadLabel {
-    fn as_str(&self) -> String {
-        let prefix = "Autoload:";
-
+    fn as_str(&self) -> &str {
         match self {
-            AutoloadLabel::Enabled => format!("{} enabled", prefix),
-            AutoloadLabel::Disabled => format!("{} disabled", prefix),
-        }
-    }
-
-    fn get_label() -> String {
-        if is_autoload_enabled() {
-            AutoloadLabel::Enabled.as_str()
-        } else {
-            AutoloadLabel::Disabled.as_str()
+            AutoloadLabel::Autoload => "Autoload",
         }
     }
 }
 
 enum DefaultCapsLockBehaviourLabel {
-    Enabled,
-    Disabled,
+    DefaultCapsLockBehaviour,
 }
 
 impl DefaultCapsLockBehaviourLabel {
-    fn as_str(&self) -> String {
-        let prefix = "Default CapsLock behaviour (Shift+CapsLock):";
-
+    fn as_str(&self) -> &str {
         match self {
-            DefaultCapsLockBehaviourLabel::Enabled => format!("{} enabled", prefix),
-            DefaultCapsLockBehaviourLabel::Disabled => format!("{} disabled", prefix),
-        }
-    }
-
-    fn get_label(is_enabled: &bool) -> String {
-        if *is_enabled {
-            DefaultCapsLockBehaviourLabel::Enabled.as_str()
-        } else {
-            DefaultCapsLockBehaviourLabel::Disabled.as_str()
+            DefaultCapsLockBehaviourLabel::DefaultCapsLockBehaviour => {
+                "Default CapsLock behaviour (Shift+CapsLock)"
+            }
         }
     }
 }
 
 struct MenuItems {
     toggle: MenuItem,
-    prev_mode: MenuItem,
-    autoload: MenuItem,
-    default_capslock_behaviour: MenuItem,
-    separator: PredefinedMenuItem,
+    top_separator: PredefinedMenuItem,
+    prev_mode: CheckMenuItem,
+    default_capslock_behaviour: CheckMenuItem,
+    autoload: CheckMenuItem,
+    bottom_separator: PredefinedMenuItem,
     about: PredefinedMenuItem,
     quit: MenuItem,
 }
@@ -146,22 +113,23 @@ fn get_menu_items() -> MenuItems {
         .text(ToggleLabel::Pause.as_str())
         .enabled(true)
         .build();
-    let menu_i_prev_mode: MenuItem = MenuItemBuilder::new()
+    let top_separator = PredefinedMenuItem::separator();
+    let menu_i_prev_mode: CheckMenuItem = CheckMenuItemBuilder::new()
         .id(MenuId::new("mode"))
-        .text(ModeLabel::get_label(&APP_STATE.is_previous_mode().unwrap()))
+        .text(ModeLabel::Previous.as_str())
+        .checked(APP_STATE.is_previous_mode().unwrap())
         .enabled(true)
         .build();
-    let menu_i_autoload: MenuItem = MenuItemBuilder::new()
-        .id(MenuId::new("autoload"))
-        .text(AutoloadLabel::get_label())
-        .enabled(true)
-        .build();
-
-    let menu_i_default_capslock_behaviour: MenuItem = MenuItemBuilder::new()
+    let menu_i_default_capslock_behaviour: CheckMenuItem = CheckMenuItemBuilder::new()
         .id(MenuId::new("default_capslock_behaviour"))
-        .text(DefaultCapsLockBehaviourLabel::get_label(
-            &APP_STATE.is_default_capslock_behaviour_enabled().unwrap(),
-        ))
+        .text(DefaultCapsLockBehaviourLabel::DefaultCapsLockBehaviour.as_str())
+        .checked(APP_STATE.is_default_capslock_behaviour_enabled().unwrap())
+        .enabled(true)
+        .build();
+    let menu_i_autoload: CheckMenuItem = CheckMenuItemBuilder::new()
+        .id(MenuId::new("autoload"))
+        .text(AutoloadLabel::Autoload.as_str())
+        .checked(is_autoload_enabled())
         .enabled(true)
         .build();
 
@@ -171,16 +139,17 @@ fn get_menu_items() -> MenuItems {
         .enabled(true)
         .build();
 
-    let separator = PredefinedMenuItem::separator();
+    let bottom_separator = PredefinedMenuItem::separator();
 
     let metadata = get_metadata();
     let menu_i_about: PredefinedMenuItem = PredefinedMenuItem::about(Some("About"), Some(metadata));
     let items = MenuItems {
         toggle: menu_i_toggle,
+        top_separator,
         prev_mode: menu_i_prev_mode,
         autoload: menu_i_autoload,
         default_capslock_behaviour: menu_i_default_capslock_behaviour,
-        separator,
+        bottom_separator,
         about: menu_i_about,
         quit: menu_i_quit,
     };
@@ -188,11 +157,11 @@ fn get_menu_items() -> MenuItems {
     items
 }
 
-fn autoload_handler(menu_i: &MenuItem) {
+fn autoload_handler(menu_i: &CheckMenuItem) {
     if is_autoload_enabled() {
         let result = remove_autoload();
         if result {
-            menu_i.set_text(AutoloadLabel::Disabled.as_str());
+            menu_i.set_checked(false);
         }
     } else {
         let is_prev_mode = APP_STATE.is_previous_mode().unwrap_or_else(|e| {
@@ -207,16 +176,15 @@ fn autoload_handler(menu_i: &MenuItem) {
         });
 
         if result {
-            menu_i.set_text(AutoloadLabel::Enabled.as_str());
+            menu_i.set_checked(true);
         }
     }
 }
 
-fn mode_hander(menu_i: &MenuItem) {
+fn mode_hander(menu_i: &CheckMenuItem) {
     match APP_STATE.toggle_previous_mode() {
         Ok(is_prev_mode) => {
-            let text = ModeLabel::get_label(&is_prev_mode);
-            menu_i.set_text(text);
+            menu_i.set_checked(is_prev_mode);
 
             if is_autoload_enabled() {
                 if is_prev_mode {
@@ -255,11 +223,10 @@ fn quit_hander() {
     process::exit(0);
 }
 
-fn default_capslock_behaviour_handler(menu_i: &MenuItem) {
+fn default_capslock_behaviour_handler(menu_i: &CheckMenuItem) {
     match APP_STATE.toggle_default_capslock_behaviour() {
         Ok(is_enabled) => {
-            let text = DefaultCapsLockBehaviourLabel::get_label(&is_enabled);
-            menu_i.set_text(text);
+            menu_i.set_checked(is_enabled);
         }
         Err(err) => {
             eprintln!(
@@ -278,10 +245,11 @@ pub fn create_tray() {
         tray_menu
             .append_items(&[
                 &menu_items.toggle,
+                &menu_items.top_separator,
                 &menu_items.prev_mode,
                 &menu_items.autoload,
                 &menu_items.default_capslock_behaviour,
-                &menu_items.separator,
+                &menu_items.bottom_separator,
                 &menu_items.about,
                 &menu_items.quit,
             ])


### PR DESCRIPTION
Hello! 

I added two small improvements:
- Added new tray menu item to toggle Shift+CapsLock behavior
- Updated tray menu to use native Windows checkmarks for toggleable items instead of "enabled/disabled" text


![{1B8EBFF3-625B-4BEA-80FC-74F78E63C36E}](https://github.com/user-attachments/assets/bad38117-2160-4f0c-9ac0-9709872b308c)
->
![{83807F71-B6A0-4E23-848F-6C128DDC8115}](https://github.com/user-attachments/assets/886fba66-9b8c-43db-9f73-83c5ddc6ad47)
